### PR TITLE
Review/train fixes

### DIFF
--- a/initializer.sh
+++ b/initializer.sh
@@ -116,7 +116,7 @@ case "$MANAGER" in
 
 uv)
     info "Syncing dependencies with uv..."
-    uv sync --quiet
+    uv sync
     PYTHON_RUN="uv run python"
     success "uv: $(uv --version) — dependencies up to date."
     ;;

--- a/src/ml/train.py
+++ b/src/ml/train.py
@@ -57,8 +57,8 @@ class Trainer:
             total += labels.size(0)
             correct += predicted.eq(labels).sum().item()
 
-            if batch_idx % 100 == 0 and batch_idx > 0:
-                avg_loss = running_loss / 100
+            if (batch_idx % 100 == 0 and batch_idx > 0) or batch_idx == len(self.train_loader) - 1:
+                avg_loss = running_loss / (batch_idx % 100 or 100)
                 accuracy = 100.0 * correct / total
                 print(
                     f"  Batch {batch_idx:03d}/{len(self.train_loader)} | Loss: {avg_loss:.4f} | Acc: {accuracy:.2f}%"

--- a/src/ml/train.py
+++ b/src/ml/train.py
@@ -5,6 +5,7 @@
 #  Modified: 2026-03-15
 # ===========================================================
 
+from dataclasses import dataclass
 from pathlib import Path
 
 import torch
@@ -15,6 +16,27 @@ from torch.optim.lr_scheduler import CosineAnnealingLR
 from src.config import cfg
 from src.ml.dataset import get_dataloaders
 from src.ml.model import SimpleCNN
+
+
+@dataclass
+class Metrics:
+    """Tracks loss, correct predictions, and total samples."""
+
+    loss: float = 0.0
+    correct: int = 0
+    total: int = 0
+
+    def reset(self) -> None:
+        self.loss = 0.0
+        self.correct = 0
+        self.total = 0
+
+    @property
+    def accuracy(self) -> float:
+        return 100.0 * self.correct / self.total if self.total else 0.0
+
+    def avg_loss(self, window: int) -> float:
+        return self.loss / window if window else 0.0
 
 
 class Trainer:
@@ -40,9 +62,7 @@ class Trainer:
     def train_one_epoch(self) -> None:
         """Executes a single training epoch over the dataset."""
         self.model.train()
-        running_loss = 0.0
-        correct = 0
-        total = 0
+        metrics = Metrics()
 
         for batch_idx, (inputs, labels) in enumerate(self.train_loader):
             inputs, labels = inputs.to(self.device), labels.to(self.device)
@@ -54,27 +74,22 @@ class Trainer:
             self.optimizer.step()
 
             _, predicted = outputs.max(1)
-            total += labels.size(0)
-            correct += predicted.eq(labels).sum().item()
+            metrics.total += labels.size(0)
+            metrics.correct += predicted.eq(labels).sum().item()
 
             if (batch_idx % 100 == 0 and batch_idx > 0) or batch_idx == len(self.train_loader) - 1:
-                avg_loss = running_loss / (batch_idx % 100 or 100)
-                accuracy = 100.0 * correct / total
+                window = batch_idx % 100 or 100
                 print(
-                    f"  Batch {batch_idx:03d}/{len(self.train_loader)} | Loss: {avg_loss:.4f} | Acc: {accuracy:.2f}%"
+                    f"  Batch {batch_idx:03d}/{len(self.train_loader)} | Loss: {metrics.avg_loss(window):.4f} | Acc: {metrics.accuracy:.2f}%"
                 )
-                running_loss = 0.0
-                correct = 0
-                total = 0
+                metrics.reset()
 
-            running_loss += loss.item()
+            metrics.loss += loss.item()
 
     def evaluate(self) -> tuple[float, float]:
         """Evaluates the model on the test dataset."""
         self.model.eval()
-        test_loss = 0.0
-        test_correct = 0
-        test_total = 0
+        metrics = Metrics()
 
         with torch.no_grad():
             for inputs, labels in self.test_loader:
@@ -82,14 +97,12 @@ class Trainer:
                 outputs = self.model(inputs)
                 loss = self.criterion(outputs, labels)
 
-                test_loss += loss.item()
+                metrics.loss += loss.item()
                 _, predicted = outputs.max(1)
-                test_total += labels.size(0)
-                test_correct += predicted.eq(labels).sum().item()
+                metrics.total += labels.size(0)
+                metrics.correct += predicted.eq(labels).sum().item()
 
-        accuracy = 100.0 * test_correct / test_total
-        avg_loss = test_loss / len(self.test_loader)
-        return avg_loss, accuracy
+        return metrics.avg_loss(len(self.test_loader)), metrics.accuracy
 
     def save(self) -> None:
         """Saves the model weights to the configured directory."""
@@ -116,7 +129,6 @@ class Trainer:
             )
 
         self.save()
-
 
 if __name__ == "__main__":
     Trainer().run()

--- a/src/ml/train.py
+++ b/src/ml/train.py
@@ -17,147 +17,104 @@ from src.ml.dataset import get_dataloaders
 from src.ml.model import SimpleCNN
 
 
-def train_one_epoch(
-    model: nn.Module,
-    train_loader: torch.utils.data.DataLoader,
-    criterion: nn.Module,
-    optimizer: optim.Optimizer,
-    device: torch.device,
-) -> None:
-    """
-    Executes a single training epoch over the dataset.
+class Trainer:
+    """Orchestrates the complete training pipeline for the CNN model."""
 
-    This function iterates through the provided training DataLoader, performs
-    the forward pass, calculates the loss, and executes the backward pass to
-    update the model's weights. It also logs the running loss and accuracy
-    metrics to the console every 100 batches.
+    def __init__(self, save_dir: str = "./checkpoints"):
+        self.save_dir = Path(save_dir)
+        self.save_dir.mkdir(parents=True, exist_ok=True)
 
-    Args:
-        model (nn.Module): The PyTorch model to be trained.
-        train_loader (torch.utils.data.DataLoader): The DataLoader providing the training batches.
-        criterion (nn.Module): The loss function used for optimization.
-        optimizer (optim.Optimizer): The optimizer algorithm (e.g., Adam) to update weights.
-        device (torch.device): The hardware device (CPU, CUDA, MPS) to perform computations on.
-    """
-    model.train()
-    running_loss = 0.0
-    correct = 0
-    total = 0
+        if torch.cuda.is_available():
+            self.device = torch.device("cuda")
+        elif torch.backends.mps.is_available():
+            self.device = torch.device("mps")
+        else:
+            self.device = torch.device("cpu")
 
-    for batch_idx, (inputs, labels) in enumerate(train_loader):
-        inputs, labels = inputs.to(device), labels.to(device)
+        self.train_loader, self.test_loader = get_dataloaders()
+        self.model = SimpleCNN().to(self.device)
+        self.criterion = nn.CrossEntropyLoss()
+        self.optimizer = optim.Adam(self.model.parameters(), lr=cfg.ml.learning_rate)
+        self.scheduler = CosineAnnealingLR(self.optimizer, T_max=cfg.ml.epoch)
 
-        optimizer.zero_grad()
-        outputs = model(inputs)
-        loss = criterion(outputs, labels)
-        loss.backward()
-        optimizer.step()
+    def train_one_epoch(self) -> None:
+        """Executes a single training epoch over the dataset."""
+        self.model.train()
+        running_loss = 0.0
+        correct = 0
+        total = 0
 
-        _, predicted = outputs.max(1)
-        total += labels.size(0)
-        correct += predicted.eq(labels).sum().item()
+        for batch_idx, (inputs, labels) in enumerate(self.train_loader):
+            inputs, labels = inputs.to(self.device), labels.to(self.device)
 
-        if batch_idx % 100 == 0 and batch_idx > 0:
-            avg_loss = running_loss / 100
-            accuracy = 100.0 * correct / total
-            print(
-                f"  Batch {batch_idx:03d}/{len(train_loader)} | Loss: {avg_loss:.4f} | Acc: {accuracy:.2f}%"
-            )
-            running_loss = 0.0
+            self.optimizer.zero_grad()
+            outputs = self.model(inputs)
+            loss = self.criterion(outputs, labels)
+            loss.backward()
+            self.optimizer.step()
 
-        running_loss += loss.item()
-
-
-def evaluate_model(
-    model: nn.Module,
-    test_loader: torch.utils.data.DataLoader,
-    criterion: nn.Module,
-    device: torch.device,
-) -> tuple[float, float]:
-    """
-    Evaluates the model on the validation or test dataset.
-
-    This function runs the model in evaluation mode (disabling dropout, batch norm updates)
-    and within a `torch.no_grad()` context block to save memory and skip gradient computations.
-    It calculates the overall accuracy and average loss across the entire dataset.
-
-    Args:
-        model (nn.Module): The PyTorch model to evaluate.
-        test_loader (torch.utils.data.DataLoader): The DataLoader providing the validation batches.
-        criterion (nn.Module): The loss function used to evaluate model performance.
-        device (torch.device): The hardware device for computation.
-
-    Returns:
-        tuple[float, float]: A tuple containing (average_loss, accuracy_percentage).
-    """
-    model.eval()
-    test_loss = 0.0
-    test_correct = 0
-    test_total = 0
-
-    with torch.no_grad():
-        for inputs, labels in test_loader:
-            inputs, labels = inputs.to(device), labels.to(device)
-            outputs = model(inputs)
-            loss = criterion(outputs, labels)
-
-            test_loss += loss.item()
             _, predicted = outputs.max(1)
-            test_total += labels.size(0)
-            test_correct += predicted.eq(labels).sum().item()
+            total += labels.size(0)
+            correct += predicted.eq(labels).sum().item()
 
-    accuracy = 100.0 * test_correct / test_total
-    avg_loss = test_loss / len(test_loader)
-    return avg_loss, accuracy
+            if batch_idx % 100 == 0 and batch_idx > 0:
+                avg_loss = running_loss / 100
+                accuracy = 100.0 * correct / total
+                print(
+                    f"  Batch {batch_idx:03d}/{len(self.train_loader)} | Loss: {avg_loss:.4f} | Acc: {accuracy:.2f}%"
+                )
+                running_loss = 0.0
 
+            running_loss += loss.item()
 
-def train_model(save_dir: str = "./checkpoints"):
-    """
-    Orchestrates the complete training pipeline for the CNN model.
+    def evaluate(self) -> tuple[float, float]:
+        """Evaluates the model on the test dataset."""
+        self.model.eval()
+        test_loss = 0.0
+        test_correct = 0
+        test_total = 0
 
-    This function handles the high-level flow:
-    1. Sets up the execution environment and target device.
-    2. Initializes the dataloaders, model, loss function, and optimizer.
-    3. Manages the epoch loop, calling the training and evaluation functions sequentially.
-    4. Saves the final trained model weights to the specified directory.
+        with torch.no_grad():
+            for inputs, labels in self.test_loader:
+                inputs, labels = inputs.to(self.device), labels.to(self.device)
+                outputs = self.model(inputs)
+                loss = self.criterion(outputs, labels)
 
-    Args:
-        save_dir (str, optional): The directory path where the model weights ('cifar10.pth')
-                                  will be saved. Defaults to "./checkpoints".
-    """
-    Path(save_dir).mkdir(parents=True, exist_ok=True)
-    device = torch.device(
-        "cuda"
-        if torch.cuda.is_available()
-        else "mps" if torch.backends.mps.is_available() else "cpu"
-    )
-    print(f"Starting training on: {device.type.upper()}")
+                test_loss += loss.item()
+                _, predicted = outputs.max(1)
+                test_total += labels.size(0)
+                test_correct += predicted.eq(labels).sum().item()
 
-    train_loader, test_loader = get_dataloaders()
-    model = SimpleCNN().to(device)
-    criterion = nn.CrossEntropyLoss()
-    optimizer = optim.Adam(model.parameters(), lr=cfg.ml.learning_rate)
-    scheduler = CosineAnnealingLR(optimizer, T_max=cfg.ml.epoch)
+        accuracy = 100.0 * test_correct / test_total
+        avg_loss = test_loss / len(self.test_loader)
+        return avg_loss, accuracy
 
-    print(
-        f"Configuration: {cfg.ml.epoch} epochs | Batch Size: {cfg.ml.batch_size} | LR: {cfg.ml.learning_rate} (CosineAnnealing)"
-    )
+    def save(self) -> None:
+        """Saves the model weights to the configured directory."""
+        save_path = self.save_dir / "cifar10.pth"
+        torch.save(self.model.state_dict(), save_path)
+        print(f"Model successfully saved at: {save_path}")
+        print("The model is ready to be transferred to Hardware!")
 
-    for epoch in range(1, cfg.ml.epoch + 1):
-        print(f"\n--- Iteration {epoch}/{cfg.ml.epoch} ---")
-        train_one_epoch(model, train_loader, criterion, optimizer, device)
-        scheduler.step()
-
-        val_loss, val_acc = evaluate_model(model, test_loader, criterion, device)
+    def run(self) -> None:
+        """Runs the full training pipeline: epochs loop + evaluation + save."""
+        print(f"Starting training on: {self.device.type.upper()}")
         print(
-            f"End of Epoch {epoch} | Test Loss: {val_loss:.4f} | Test Acc: {val_acc:.2f}%\n"
+            f"Configuration: {cfg.ml.epoch} epochs | Batch Size: {cfg.ml.batch_size} | LR: {cfg.ml.learning_rate} (CosineAnnealing)"
         )
 
-    save_path = f"{save_dir}/cifar10.pth"
-    torch.save(model.state_dict(), save_path)
-    print(f"Model successfully saved at: {save_path}")
-    print("The model is ready to be transferred to Hardware!")
+        for epoch in range(1, cfg.ml.epoch + 1):
+            print(f"\n--- Iteration {epoch}/{cfg.ml.epoch} ---")
+            self.train_one_epoch()
+            self.scheduler.step()
+
+            val_loss, val_acc = self.evaluate()
+            print(
+                f"End of Epoch {epoch} | Test Loss: {val_loss:.4f} | Test Acc: {val_acc:.2f}%\n"
+            )
+
+        self.save()
 
 
 if __name__ == "__main__":
-    train_model()
+    Trainer().run()

--- a/src/ml/train.py
+++ b/src/ml/train.py
@@ -53,7 +53,6 @@ def train_one_epoch(
         loss.backward()
         optimizer.step()
 
-        running_loss += loss.item()
         _, predicted = outputs.max(1)
         total += labels.size(0)
         correct += predicted.eq(labels).sum().item()
@@ -65,6 +64,8 @@ def train_one_epoch(
                 f"  Batch {batch_idx:03d}/{len(train_loader)} | Loss: {avg_loss:.4f} | Acc: {accuracy:.2f}%"
             )
             running_loss = 0.0
+
+        running_loss += loss.item()
 
 
 def evaluate_model(

--- a/src/ml/train.py
+++ b/src/ml/train.py
@@ -118,6 +118,8 @@ class Trainer:
             f"Configuration: {cfg.ml.epoch} epochs | Batch Size: {cfg.ml.batch_size} | LR: {cfg.ml.learning_rate} (CosineAnnealing)"
         )
 
+        best_acc = 0.0
+
         for epoch in range(1, cfg.ml.epoch + 1):
             print(f"\n--- Iteration {epoch}/{cfg.ml.epoch} ---")
             self.train_one_epoch()
@@ -128,7 +130,11 @@ class Trainer:
                 f"End of Epoch {epoch} | Test Loss: {val_loss:.4f} | Test Acc: {val_acc:.2f}%\n"
             )
 
-        self.save()
+            if val_acc > best_acc:
+                best_acc = val_acc
+                self.save()
+
+        print(f"Best Test Acc: {best_acc:.2f}%")
 
 if __name__ == "__main__":
     Trainer().run()

--- a/src/ml/train.py
+++ b/src/ml/train.py
@@ -64,6 +64,8 @@ class Trainer:
                     f"  Batch {batch_idx:03d}/{len(self.train_loader)} | Loss: {avg_loss:.4f} | Acc: {accuracy:.2f}%"
                 )
                 running_loss = 0.0
+                correct = 0
+                total = 0
 
             running_loss += loss.item()
 


### PR DESCRIPTION
- Fix off-by-one on avg_loss (101 terms divided by 100)
- Align accuracy and loss on the same 100-batch window
- Display the last batch segment (701-781) that was silent
- Extract a Metrics dataclass to replace floating variables
- Save the best model (best accuracy) instead of the last
- Migrate to OOP with a Trainer class